### PR TITLE
transfer to minio only files that respect the naming rules

### DIFF
--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
@@ -20,19 +20,21 @@ import java.util.regex.Pattern;
  */
 @Component
 public class FileMetadataProvider implements MetadataProvider {
+    private final FileNameConfiguration fileNameConfiguration;
     public static final String GRIDCAPA_FILE_NAME_KEY = "gridcapa_file_name";
 
     static final String GRIDCAPA_TARGET_PROCESS_METADATA_KEY = "gridcapa_process";
     static final String GRIDCAPA_FILE_TYPE_METADATA_KEY = "gridcapa_file_type";
     static final String GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY = "gridcapa_file_validity_interval";
 
+    public FileMetadataProvider(FileNameConfiguration filenamesConfiguration) {
+        this.fileNameConfiguration = filenamesConfiguration;
+    }
+
     @Value("${data-bridge.target-process}")
     private String targetProcess;
     @Value("${data-bridge.file-type}")
     private String fileType;
-
-    @Value("${data-bridge.file-regex}")
-    private String fileRegex;
 
     @Override
     public void populateMetadata(Message<?> message, Map<String, String> metadata) {
@@ -48,7 +50,7 @@ public class FileMetadataProvider implements MetadataProvider {
         if (fileName == null || fileName.isEmpty()) {
             return "";
         }
-        Pattern pattern = Pattern.compile(fileRegex);
+        Pattern pattern = Pattern.compile(fileNameConfiguration.getFileNameRegex());
         Matcher matcher = pattern.matcher(fileName);
         if (matcher.matches()) {
             int year = Integer.parseInt(matcher.group("year"));

--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileNameConfiguration.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileNameConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.gridcapa.data_bridge;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Amira Kahya {@literal <amira.kahya at rte-france.com>}
+ */
+@Configuration
+public class FileNameConfiguration {
+
+    @Value("${data-bridge.file-regex}")
+    private String fileNameRegex;
+
+    public String getFileNameRegex() {
+        return fileNameRegex;
+    }
+}


### PR DESCRIPTION
Signed-off-by: AMIRA KAHYA <amira.kahya@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What is the current behavior?** *(You can also link to an open issue here)*
All files can be transferred to minio even if they do not respect the files naming rules. 

**What is the new behavior (if this is a feature change)?**
Transfer to minio only files that respect the naming rules 


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
