### PR TITLE
Migrate to gridcapa-starter-minio-adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <!-- Dependency versions -->
         <spring.integration.aws.version>2.4.0</spring.integration.aws.version>
         <spring.integration.zip.version>1.0.3.RELEASE</spring.integration.zip.version>
+        <gridcapa.starter.minio.adapter.version>0.1.0</gridcapa.starter.minio.adapter.version>
     </properties>
 
     <build>
@@ -41,6 +42,11 @@
 
     <dependencies>
         <!-- Compile dependencies -->
+        <dependency>
+            <groupId>com.farao-community.farao</groupId>
+            <artifactId>gridacapa-starter-minio-adapter</artifactId>
+            <version>${gridcapa.starter.minio.adapter.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <!-- Compile dependencies -->
         <dependency>
             <groupId>com.farao-community.farao</groupId>
-            <artifactId>gridacapa-starter-minio-adapter</artifactId>
+            <artifactId>gridcapa-starter-minio-adapter</artifactId>
             <version>${gridcapa.starter.minio.adapter.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <!-- Dependency versions -->
         <spring.integration.aws.version>2.4.0</spring.integration.aws.version>
         <spring.integration.zip.version>1.0.3.RELEASE</spring.integration.zip.version>
-        <gridcapa.starter.minio.adapter.version>0.1.0</gridcapa.starter.minio.adapter.version>
+        <gridcapa.starter.minio.adapter.version>0.2.0</gridcapa.starter.minio.adapter.version>
     </properties>
 
     <build>

--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/DataBridgeApplication.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/DataBridgeApplication.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.gridcapa.data_bridge;
 
+import com.farao_community.farao.minio_adapter.starter.MinioAdapterAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -14,7 +15,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @author Alexandre Montigny {@literal <alexandre.montigny at rte-france.com>}
  */
 @SuppressWarnings("hideutilityclassconstructor")
-@SpringBootApplication
+@SpringBootApplication(exclude = MinioAdapterAutoConfiguration.class)
 public class DataBridgeApplication {
     public static void main(String[] args) {
         SpringApplication.run(DataBridgeApplication.class, args);

--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
@@ -20,11 +20,11 @@ import java.util.regex.Pattern;
  */
 @Component
 public class FileMetadataProvider implements MetadataProvider {
-    private static final String GRIDCAPA_FILE_GROUP_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_GROUP_METADATA_KEY);
-    private static final String GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY);
-    private static final String GRIDCAPA_FILE_TYPE_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TYPE_METADATA_KEY);
-    private static final String GRIDCAPA_FILE_NAME_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY);
-    private static final String GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY);
+    static final String GRIDCAPA_FILE_GROUP_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_GROUP_METADATA_KEY);
+    static final String GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY);
+    static final String GRIDCAPA_FILE_TYPE_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TYPE_METADATA_KEY);
+    static final String GRIDCAPA_FILE_NAME_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY);
+    static final String GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY);
 
     private final FileMetadataConfiguration fileMetadataConfiguration;
 

--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.gridcapa.data_bridge;
 
+import com.farao_community.farao.minio_adapter.starter.MinioAdapterConstants;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
@@ -19,11 +20,11 @@ import java.util.regex.Pattern;
  */
 @Component
 public class FileMetadataProvider implements MetadataProvider {
-    public static final String GRIDCAPA_FILE_NAME_KEY = "gridcapa_file_name";
-
-    static final String GRIDCAPA_TARGET_PROCESS_METADATA_KEY = "gridcapa_file_target_process";
-    static final String GRIDCAPA_FILE_TYPE_METADATA_KEY = "gridcapa_file_type";
-    static final String GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY = "gridcapa_file_validity_interval";
+    private static final String GRIDCAPA_FILE_GROUP_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_GROUP_METADATA_KEY);
+    private static final String GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY);
+    private static final String GRIDCAPA_FILE_TYPE_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TYPE_METADATA_KEY);
+    private static final String GRIDCAPA_FILE_NAME_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY);
+    private static final String GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY = removeXAmzMetaPrefix(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY);
 
     private final FileMetadataConfiguration fileMetadataConfiguration;
 
@@ -31,12 +32,18 @@ public class FileMetadataProvider implements MetadataProvider {
         this.fileMetadataConfiguration = fileMetadataConfiguration;
     }
 
+    private static String removeXAmzMetaPrefix(String metadataKey) {
+        String prefixToBeRemoved = "x-amz-meta-";
+        return metadataKey.toLowerCase().startsWith(prefixToBeRemoved) ? metadataKey.substring(prefixToBeRemoved.length()) : metadataKey;
+    }
+
     @Override
     public void populateMetadata(Message<?> message, Map<String, String> metadata) {
-        metadata.put(GRIDCAPA_TARGET_PROCESS_METADATA_KEY, fileMetadataConfiguration.getTargetProcess());
+        metadata.put(GRIDCAPA_FILE_GROUP_METADATA_KEY, MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE);
+        metadata.put(GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY, fileMetadataConfiguration.getTargetProcess());
         metadata.put(GRIDCAPA_FILE_TYPE_METADATA_KEY, fileMetadataConfiguration.getFileType());
-        String fileName = message.getHeaders().get(GRIDCAPA_FILE_NAME_KEY, String.class);
-        metadata.put(GRIDCAPA_FILE_NAME_KEY, fileName);
+        String fileName = message.getHeaders().get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, String.class);
+        metadata.put(GRIDCAPA_FILE_NAME_METADATA_KEY, fileName);
         String fileValidityInterval = getFileValidityIntervalMetadata(fileName);
         metadata.put(GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY, fileValidityInterval);
     }

--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileTransferFlow.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileTransferFlow.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.gridcapa.data_bridge;
 
+import com.farao_community.farao.minio_adapter.starter.MinioAdapterConstants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -71,7 +72,7 @@ public class FileTransferFlow {
     private Message<File> addFileNameHeader(Message<File> message) {
         String filename = (String) message.getHeaders().get("file_name");
         return MessageBuilder.fromMessage(message)
-                .setHeader(FileMetadataProvider.GRIDCAPA_FILE_NAME_KEY, filename)
+                .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, filename)
                 .build();
     }
 

--- a/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
@@ -189,10 +189,10 @@ class FileMetadataProviderTest {
     }
 
     void assertAllInputFileMetadataEquals(Map<String, String> actualMetadata, String targetProcess, String fileType, String fileName, String fileValidityInterval) {
-        assertEquals(MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_GROUP_METADATA_KEY));
-        assertEquals(targetProcess, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY));
-        assertEquals(fileType, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TYPE_METADATA_KEY));
-        assertEquals(fileName, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY));
-        assertEquals(fileValidityInterval, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertEquals(MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE, actualMetadata.get(FileMetadataProvider.GRIDCAPA_FILE_GROUP_METADATA_KEY));
+        assertEquals(targetProcess, actualMetadata.get(FileMetadataProvider.GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY));
+        assertEquals(fileType, actualMetadata.get(FileMetadataProvider.GRIDCAPA_FILE_TYPE_METADATA_KEY));
+        assertEquals(fileName, actualMetadata.get(FileMetadataProvider.GRIDCAPA_FILE_NAME_METADATA_KEY));
+        assertEquals(fileValidityInterval, actualMetadata.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
     }
 }

--- a/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.gridcapa.data_bridge;
 
+import com.farao_community.farao.minio_adapter.starter.MinioAdapterConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,15 +52,12 @@ class FileMetadataProviderTest {
         );
         Message<?> ucteFileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "20210101_1430_2D5_CSE1.uct")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "20210101_1430_2D5_CSE1.uct")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap);
 
-        assertEquals("CSE_D2CC", metadataMap.get(FileMetadataProvider.GRIDCAPA_TARGET_PROCESS_METADATA_KEY));
-        assertEquals("CGM", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_TYPE_METADATA_KEY));
-        assertEquals("20210101_1430_2D5_CSE1.uct", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_NAME_KEY));
-        assertEquals("2021-01-01T13:30Z/2021-01-01T14:30Z", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "CGM", "20210101_1430_2D5_CSE1.uct", "2021-01-01T13:30Z/2021-01-01T14:30Z");
     }
 
     @Test
@@ -73,11 +71,11 @@ class FileMetadataProviderTest {
         );
         Message<?> ucteFileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "20210101_2330_2D5_CSE1.uct")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "20210101_2330_2D5_CSE1.uct")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap);
-        assertEquals("2021-01-01T23:30Z/2021-01-02T00:30Z", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "CGM", "20210101_2330_2D5_CSE1.uct", "2021-01-01T23:30Z/2021-01-02T00:30Z");
     }
 
     @Test
@@ -91,15 +89,12 @@ class FileMetadataProviderTest {
         );
         Message<?> ucteFileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "2021_test.xml")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "2021_test.xml")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap);
 
-        assertEquals("CSE_D2CC", metadataMap.get(FileMetadataProvider.GRIDCAPA_TARGET_PROCESS_METADATA_KEY));
-        assertEquals("CGM", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_TYPE_METADATA_KEY));
-        assertEquals("2021_test.xml", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_NAME_KEY));
-        assertEquals("2020-12-31T23:30Z/2021-12-31T23:30Z", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "CGM", "2021_test.xml", "2020-12-31T23:30Z/2021-12-31T23:30Z");
     }
 
     @Test
@@ -113,15 +108,12 @@ class FileMetadataProviderTest {
         );
         Message<?> ucteFileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "test_2021.xml")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "test_2021.xml")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap);
 
-        assertEquals("CSE_D2CC", metadataMap.get(FileMetadataProvider.GRIDCAPA_TARGET_PROCESS_METADATA_KEY));
-        assertEquals("CGM", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_TYPE_METADATA_KEY));
-        assertEquals("test_2021.xml", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_NAME_KEY));
-        assertEquals("", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "CGM", "test_2021.xml", "");
     }
 
     @Test
@@ -135,7 +127,7 @@ class FileMetadataProviderTest {
         );
         Message<?> ucteFileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "09_test.xml")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "09_test.xml")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         assertThrows(DataBridgeException.class, () -> fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap));
@@ -152,15 +144,12 @@ class FileMetadataProviderTest {
         );
         Message<?> fileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "20210101_test.xml")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "20210101_test.xml")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         fileMetadataProvider.populateMetadata(fileMessage, metadataMap);
 
-        assertEquals("CSE_D2CC", metadataMap.get(FileMetadataProvider.GRIDCAPA_TARGET_PROCESS_METADATA_KEY));
-        assertEquals("NTC_RED", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_TYPE_METADATA_KEY));
-        assertEquals("20210101_test.xml", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_NAME_KEY));
-        assertEquals("2020-12-31T23:30Z/2021-01-01T23:30Z", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "NTC_RED", "20210101_test.xml", "2020-12-31T23:30Z/2021-01-01T23:30Z");
     }
 
     @Test
@@ -174,7 +163,7 @@ class FileMetadataProviderTest {
         );
         Message<?> fileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "202002_test.xml")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "202002_test.xml")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         assertThrows(DataBridgeException.class, () -> fileMetadataProvider.populateMetadata(fileMessage, metadataMap));
@@ -191,14 +180,19 @@ class FileMetadataProviderTest {
         );
         Message<?> fileMessage = MessageBuilder
             .withPayload("")
-            .setHeader("gridcapa_file_name", "test_20210203.xml")
+            .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "test_20210203.xml")
             .build();
         Map<String, String> metadataMap = new HashMap<>();
         fileMetadataProvider.populateMetadata(fileMessage, metadataMap);
 
-        assertEquals("CSE_D2CC", metadataMap.get(FileMetadataProvider.GRIDCAPA_TARGET_PROCESS_METADATA_KEY));
-        assertEquals("NTC_RED", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_TYPE_METADATA_KEY));
-        assertEquals("test_20210203.xml", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_NAME_KEY));
-        assertEquals("", metadataMap.get(FileMetadataProvider.GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "NTC_RED", "test_20210203.xml", "");
+    }
+
+    void assertAllInputFileMetadataEquals(Map<String, String> actualMetadata, String targetProcess, String fileType, String fileName, String fileValidityInterval) {
+        assertEquals(MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_GROUP_METADATA_KEY));
+        assertEquals(targetProcess, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TARGET_PROCESS_METADATA_KEY));
+        assertEquals(fileType, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_TYPE_METADATA_KEY));
+        assertEquals(fileName, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY));
+        assertEquals(fileValidityInterval, actualMetadata.get(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_VALIDITY_INTERVAL_METADATA_KEY));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, there is no file group metadata in files imported into MinIO by the data bridge


**What is the new behavior (if this is a feature change)?**
The new **_gridcapa_file_group_** metadata is added with value **_input_**


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:
Includes migration to new gridcapa-starter-minio-adapter to ensure metadata key and values respect the espected values in GridCapa ecosystem.

