### PR TITLE
Make yearly input being able to start on a day of the year

### DIFF
--- a/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
@@ -98,6 +98,44 @@ class FileMetadataProviderTest {
     }
 
     @Test
+    void checkMetadataSetCorrectlyWithYearlyFileStartingOnADayInSummer() {
+        mockConfig(
+                "CSE_D2CC",
+                "CGM",
+                "YEARLY",
+                "(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*",
+                "Europe/Paris"
+        );
+        Message<?> ucteFileMessage = MessageBuilder
+                .withPayload("")
+                .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "20210615_test.xml")
+                .build();
+        Map<String, String> metadataMap = new HashMap<>();
+        fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap);
+
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "CGM", "20210615_test.xml", "2021-06-14T22:30Z/2022-06-14T22:30Z");
+    }
+
+    @Test
+    void checkMetadataSetCorrectlyWithYearlyFileStartingOnADayDuringWinter() {
+        mockConfig(
+                "CSE_D2CC",
+                "CGM",
+                "YEARLY",
+                "(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*",
+                "Europe/Paris"
+        );
+        Message<?> ucteFileMessage = MessageBuilder
+                .withPayload("")
+                .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "20211105_test.xml")
+                .build();
+        Map<String, String> metadataMap = new HashMap<>();
+        fileMetadataProvider.populateMetadata(ucteFileMessage, metadataMap);
+
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "CGM", "20211105_test.xml", "2021-11-04T23:30Z/2022-11-04T23:30Z");
+    }
+
+    @Test
     void checkEmptyTimeValidityIntervalWithYearlyFileAndMalformedFileName() {
         mockConfig(
             "CSE_D2CC",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
For TargetCH files (CSE import D2CC) it requires to define a yearly file that starts in any day of the year.

