### PR TITLE
Set data timeout of FTP session factory

### DIFF
--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/sources/FtpSource.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/sources/FtpSource.java
@@ -41,6 +41,7 @@ import java.nio.file.Files;
 @ConditionalOnProperty(prefix = "data-bridge.sources.ftp", name = "active", havingValue = "true")
 public class FtpSource {
     public static final String SYNCHRONIZE_TEMP_DIRECTORY_PREFIX = "gridcapa-data-bridge";
+    public static final int DATA_TIMEOUT = 5000;
 
     private final ApplicationContext applicationContext;
     private final RemoteFileConfiguration remoteFileConfiguration;
@@ -73,6 +74,7 @@ public class FtpSource {
         ftpSessionFactory.setUsername(ftpUsername);
         ftpSessionFactory.setPassword(ftpPassword);
         ftpSessionFactory.setClientMode(FTPClient.PASSIVE_LOCAL_DATA_CONNECTION_MODE);
+        ftpSessionFactory.setDataTimeout(DATA_TIMEOUT);
         return ftpSessionFactory;
     }
 


### PR DESCRIPTION
Set data timeout of FTP session factory to solve the issue that happened when network communication was lost during a file transfer. The addition of this timeout make a correct exception to be thrown, and the file is downloaded again afterwards.

Signed-off-by: Sébastien Murgey <sebastien.murgey@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
