### PR TITLE
Fix daily file import for on the hour processes

### DIFF
--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProvider.java
@@ -124,12 +124,14 @@ public class FileMetadataProvider implements MetadataProvider {
         return dstBeginningDateTime + "/" + dstEndingDateTime;
     }
 
-    private String getDailyFileValidityIntervalMetadata(Matcher matcher) {
-        int year = parseOrThrow(matcher, YEAR);
-        int month = parseOrThrow(matcher, MONTH);
-        int day = parseOrThrow(matcher, DAY);
-        LocalDateTime beginDateTime = LocalDateTime.of(year, month, day, 0, 30);
-        LocalDateTime endDateTime = beginDateTime.plusDays(1);
+    private String getDailyFileValidityIntervalMetadata(final Matcher matcher) {
+        final int year = parseOrThrow(matcher, YEAR);
+        final int month = parseOrThrow(matcher, MONTH);
+        final int day = parseOrThrow(matcher, DAY);
+        final LocalDateTime beginDateTime = dataBridgeConfiguration.isOnTheHourProcess()
+                ? LocalDateTime.of(year, month, day, 0, 0)
+                : LocalDateTime.of(year, month, day, 0, 30);
+        final LocalDateTime endDateTime = beginDateTime.plusDays(1);
         return toUtc(beginDateTime) + "/" + toUtc(endDateTime);
     }
 

--- a/src/main/java/com/farao_community/farao/gridcapa/data_bridge/configuration/DataBridgeConfiguration.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/data_bridge/configuration/DataBridgeConfiguration.java
@@ -19,11 +19,13 @@ public class DataBridgeConfiguration {
 
     private final String targetProcess;
     private final String zoneId;
+    private final boolean isOnTheHourProcess;
     private final List<FileMetadataConfiguration> files;
 
-    public DataBridgeConfiguration(String targetProcess, String zoneId, List<FileMetadataConfiguration> files) {
+    public DataBridgeConfiguration(String targetProcess, String zoneId, boolean isOnTheHourProcess, List<FileMetadataConfiguration> files) {
         this.targetProcess = targetProcess;
         this.zoneId = zoneId;
+        this.isOnTheHourProcess = isOnTheHourProcess;
         this.files = files;
     }
 
@@ -33,6 +35,10 @@ public class DataBridgeConfiguration {
 
     public String getZoneId() {
         return zoneId;
+    }
+
+    public boolean isOnTheHourProcess() {
+        return isOnTheHourProcess;
     }
 
     public List<FileMetadataConfiguration> getFiles() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+data-bridge:
+  configuration:
+    isOnTheHourProcess: false

--- a/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/data_bridge/FileMetadataProviderTest.java
@@ -48,6 +48,11 @@ class FileMetadataProviderTest {
         Mockito.when(dataBridgeConfiguration.getFileConfigurationFromName(Mockito.anyString())).thenReturn(fileMetadataConfiguration);
     }
 
+    private void mockConfig(final boolean isOnTheHourProcess, final String targetProcess, final String fileType, final String timeValidity, final String fileRegex, final String zoneId) {
+        Mockito.when(dataBridgeConfiguration.isOnTheHourProcess()).thenReturn(isOnTheHourProcess);
+        mockConfig(targetProcess, fileType, timeValidity, fileRegex, zoneId);
+    }
+
     @Test
     void checkMetadataSetCorrectlyWhenUcteFileIsCorrect() {
         mockConfig(
@@ -195,6 +200,26 @@ class FileMetadataProviderTest {
         fileMetadataProvider.populateMetadata(fileMessage, metadataMap);
 
         assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "NTC_RED", "20210101_test.xml", "2020-12-31T23:30Z/2021-01-01T23:30Z");
+    }
+
+    @Test
+    void checkMetadataSetCorrectlyWithDailyFileOnTheHourProcess() {
+        mockConfig(
+                true,
+                "CSE_D2CC",
+                "NTC_RED",
+                "DAILY",
+                "(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*",
+                "Europe/Paris"
+        );
+        Message<?> fileMessage = MessageBuilder
+                .withPayload("")
+                .setHeader(MinioAdapterConstants.DEFAULT_GRIDCAPA_FILE_NAME_METADATA_KEY, "20210101_test.xml")
+                .build();
+        Map<String, String> metadataMap = new HashMap<>();
+        fileMetadataProvider.populateMetadata(fileMessage, metadataMap);
+
+        assertAllInputFileMetadataEquals(metadataMap, "CSE_D2CC", "NTC_RED", "20210101_test.xml", "2020-12-31T23:00Z/2021-01-01T23:00Z");
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,6 +2,7 @@ data-bridge:
   configuration:
 #    zone-id: "Europe/Paris"
     target-process: CSE_D2CC
+    isOnTheHourProcess: false
     files:
       - file-type: CGM
         file-regex: regex_test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to enable on-the-hour processing, which adjusts the daily file validity interval start time from 00:30 to 00:00.

* **Tests**
  * Added test coverage to validate the metadata validity interval behavior when on-the-hour processing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->